### PR TITLE
Resident feelings chart reactive

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -56,3 +56,4 @@ shell-server@0.2.4
 sergeyt:dimple
 dynamic-import@0.1.1
 aldeed:autoform-select2
+tmeasday:publish-counts

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -126,6 +126,7 @@ templating@1.3.2
 templating-compiler@1.3.2
 templating-runtime@1.3.2
 templating-tools@1.1.2
+tmeasday:publish-counts@0.8.0
 tracker@1.1.3
 twbs:bootstrap@3.3.6
 ui@1.0.13

--- a/client/views/resident/feelings/feelings.js
+++ b/client/views/resident/feelings/feelings.js
@@ -5,15 +5,15 @@ Template.residentFeelings.onCreated(function () {
   // Get resident ID from template instance
   const residentId = templateInstance.data.residentId;
 
-  // Set up reactive variable to hold resident feelings counts
-  templateInstance.residentFeelingsCounts = new ReactiveVar();
+  // Set up reactive variable to hold resident feelings percentages
+  templateInstance.residentFeelingsPercentages = new ReactiveVar();
 
   // Method to clear and render chart
   templateInstance.clearAndRenderChart = function (chartData) {
-    // clear any previous chart
+    // Clear any previous chart
     this.$('#residentFeelingsChart').empty();
 
-    // Render chart with current feeling counts
+    // Render chart with current feeling percentages
     MG.data_graphic({
       title: TAPi18n.__('residentFeelings-chart-title'),
       data: chartData,
@@ -46,10 +46,10 @@ Template.residentFeelings.onCreated(function () {
     return localizedChartData
   };
 
-  // Fetch resident feelings counts from server
-  Meteor.call('getFeelingsPercentagesByResidentId', residentId, function (error, residentFeelingsCounts) {
-    // Update resident feelings counts with returned value from method call
-    templateInstance.residentFeelingsCounts.set(residentFeelingsCounts);
+  // Get resident feelings percentages from server
+  Meteor.call('getFeelingsPercentagesByResidentId', residentId, function (error, residentFeelingsPercentages) {
+    // Update resident feelings percentages with returned value from method call
+    templateInstance.residentFeelingsPercentages.set(residentFeelingsPercentages);
   });
 });
 
@@ -58,19 +58,19 @@ Template.residentFeelings.onRendered(function () {
   const templateInstance = this;
 
   templateInstance.autorun(() => {
-    // Get resident feelings counts
-    const residentFeelingsCounts = templateInstance.residentFeelingsCounts.get();
+    // Get resident feelings percentages
+    const residentFeelingsPercentages = templateInstance.residentFeelingsPercentages.get();
 
-    // Make sure resident feelings counts data is available
-    if (residentFeelingsCounts) {
-      // Sort feelings counts
-      const sortedResidentFeelingsCounts = residentFeelingsCounts.sort(function (a, b) {
+    // Make sure resident feelings percentages data is available
+    if (residentFeelingsPercentages) {
+      // Sort feelings percentages
+      const sortedResidentFeelingsPercentages = residentFeelingsPercentages.sort(function (a, b) {
         // Sort from high to low
         return b.value - a.value;
       });
 
       // Create localized data for chart
-      const localizedChartData = templateInstance.localizeChartData(sortedResidentFeelingsCounts);
+      const localizedChartData = templateInstance.localizeChartData(sortedResidentFeelingsPercentages);
 
       // Render chart with localized data
       templateInstance.clearAndRenderChart(localizedChartData);
@@ -83,7 +83,7 @@ Template.residentFeelings.helpers({
     // Get reference to template instance
     const templateInstance = Template.instance();
 
-    // Return value of resident feelings count reactive variable
-    return templateInstance.residentFeelingsCounts.get();
+    // Return value of resident feelings percentages reactive variable
+    return templateInstance.residentFeelingsPercentages.get();
   }
 });

--- a/client/views/resident/feelings/feelings.js
+++ b/client/views/resident/feelings/feelings.js
@@ -19,7 +19,8 @@ Template.residentFeelings.onCreated(function () {
   // TODO: figure out a 'cleaner' way to signal that feelings data have changed
   // https://forums.meteor.com/t/send-reactive-signal-from-server-to-client/39141
   templateInstance.autorun(() => {
-    // Get resident feelings
+    // Get resident feelings count
+    // This is just a reactive trigger to fetch resident feelings percentages
     const feelingsCount = Counts.get(`resident_${ residentId }_feelings_count`);
 
     // Get resident feelings percentages when feelings count changes

--- a/client/views/resident/feelings/feelings.js
+++ b/client/views/resident/feelings/feelings.js
@@ -5,6 +5,10 @@ Template.residentFeelings.onCreated(function () {
   // Get resident ID from template instance
   const residentId = templateInstance.data.residentId;
 
+  /*
+  Template autorun
+  */
+
   // Subscribe to count of resident feelings
   // Used to trigger call to 'get resident feelings percentages' method
   // TODO: figure out a 'cleaner' way to signal that feelings data have changed
@@ -54,6 +58,7 @@ Template.residentFeelings.onCreated(function () {
     });
   };
 
+  // Method to localize chart data labels
   templateInstance.localizeChartData = function (chartData) {
     // Create localized data for chart
     const localizedChartData = _.map(chartData, function (datum) {
@@ -76,6 +81,10 @@ Template.residentFeelings.onCreated(function () {
 Template.residentFeelings.onRendered(function () {
   // Get reference to template instance
   const templateInstance = this;
+
+  /*
+  Template autorun
+  */
 
   templateInstance.autorun(() => {
     // Get resident feelings percentages

--- a/client/views/resident/feelings/feelings.js
+++ b/client/views/resident/feelings/feelings.js
@@ -82,7 +82,8 @@ Template.residentFeelings.onRendered(function () {
     const residentFeelingsPercentages = templateInstance.residentFeelingsPercentages.get();
 
     // Make sure resident feelings percentages data is available
-    if (residentFeelingsPercentages) {
+    // and not an empty array
+    if (residentFeelingsPercentages && residentFeelingsPercentages.length > 0) {
       // Sort feelings percentages
       const sortedResidentFeelingsPercentages = residentFeelingsPercentages.sort(function (a, b) {
         // Sort from high to low

--- a/server/publications/feelings.js
+++ b/server/publications/feelings.js
@@ -2,3 +2,17 @@ Meteor.publish('residentFeelings', function (residentId) {
   // Get all feelings for a given residentId
   return Feelings.find({ residentId });
 });
+
+// Count of feelings for a given residentId
+// primarily designed to 'signal' the resident feelings chart to re-render
+// TODO: figure out a 'cleaner' way to signal the feelings chart to re-render
+// https://forums.meteor.com/t/send-reactive-signal-from-server-to-client/39141
+Meteor.publish('residentFeelingsCount', function(residentId) {
+  // Create a counter for the current residentId
+  // in the form of 'resident-{ ID }-feelings-count'
+  Counts.publish(
+    this,
+    `resident_${ residentId }_feelings_count`,
+    Feelings.find({ residentId })
+  );
+});


### PR DESCRIPTION
Closes #159 

# Changes
- Add tmeasday:publish-counts package
- Change word 'counts' to 'percentages' where relevant
- Add `residentFeelingsCount` publication
- Reactively fetch resident feelings percentages from server
  - using resident feelings count as signal to trigger call to 'get resident feelings percentages'
- Ensure resident feelings percentages exists, and is not empty array, before rendering chart