### PR TITLE
Clarify resident active days count text

### DIFF
--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -154,7 +154,7 @@
   "homeResidentActivityLevelTrend-legend-inactive": "Inactive",
   "homeResidentActivityLevelTrend-legend-semiActive": "Moderate",
   "homeResidentActivityLevelTrend-yAxis-label": "Number of residents",
-  "homeResidents-tableCaption": "Residents with count of days with at least one recorded activity for past seven days. Activity level shown in parenthesis.",
+  "homeResidents-tableCaption": "Table showing residents. Next to each resident is a count of days with at least one recorded activity within past seven days. Activity level is shown in parenthesis.",
   "homeResidents-tableHeader-residentName": "Name",
   "homeResidents-tableHeader-activity": "Recent active days count (activity level)",
   "homeResidents-loadingMessage": "Loading residents",


### PR DESCRIPTION
Closes #186 

# Changes
- clarification of text describing 'resident active days count' on Home profile page