### PR TITLE
Subtract 6 days instead of 7 (from current day)

### DIFF
--- a/server/methods/homes.js
+++ b/server/methods/homes.js
@@ -168,20 +168,19 @@ Meteor.methods({
     // Get home residents
     var residentIds = Meteor.call("getHomeCurrentAndActiveResidentIds",homeId);
 
-    // Number of days to look back
-    var numberOfDays = 7;
-
     // Placeholder array for daily activity level counts
     var activityCountsArray = [];
 
-    for (var i = 0; i < numberOfDays; i++) {
-      // Get date N days ago for daily activity counts and query
-      var day = moment().startOf("day").subtract(i, "days");
-      var queryDate = moment().endOf("day").subtract(i, "days");
+    // Date one week ago (six days, since today counts as one day)
+    const startDate = moment().subtract(6, 'days');
 
+    // Get a date object for the end of day today
+    const endDate = moment().endOf('day');
+
+    for (let currentDay = moment(startDate); currentDay.isBefore(endDate); currentDay.add(1, 'day')) {
       // Set up placeholder activity counts object
       var dailyActivityCounts = {
-        date: day.toDate(),
+        date: currentDay.toDate(),
         inactive: 0,
         semiActive: 0,
         active: 0
@@ -193,7 +192,7 @@ Meteor.methods({
         var result = Meteor.call(
           "getResidentRecentActiveDaysCount",
           residentId,
-          queryDate.toDate()
+          currentDay.toDate()
         );
 
         if (result === 0) {

--- a/server/methods/residentActivities.js
+++ b/server/methods/residentActivities.js
@@ -32,8 +32,8 @@ Meteor.methods({
     // Initialize counter for resident active days
     let activeDaysCount = 0;
 
-    // Date one week ago
-    const startDate = moment(date).subtract(1, 'weeks');
+    // Date one week ago (six days, since today counts as one day)
+    const startDate = moment(date).subtract(6, 'days');
 
     // Get a date object for the end of day today
     const endDate = moment(date).endOf('day');


### PR DESCRIPTION
Closes #204 

# Changes
- use similar code for residents table and trend chart to subtract 6 days from current day in order to count number of active days for past week (seven days)