### PR TITLE
Anonymous access to resident profile

### DIFF
--- a/app/client/layouts/main/navbar.html
+++ b/app/client/layouts/main/navbar.html
@@ -14,8 +14,8 @@
 
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-        {{# if currentUser }}
         <ul class="nav navbar-nav">
+          {{# if currentUser }}
           <li>
             <a href="{{ pathFor route='residents' }}">
               <i class="fa fa-users"></i>&nbsp;
@@ -34,6 +34,7 @@
               {{_ "mainLayoutNavbar-homesLink" }}
             </a>
           </li>
+          {{/ if }}
         </ul>
 
 
@@ -43,23 +44,27 @@
               {{> i18n_dropdown}}
             </form>
           </li>
-          <li>
-            <a href="{{ pathFor 'userProfile'}}">
-              <i class="fa fa-user"></i>&nbsp;
-              {{_ "mainLayoutNavbar-profileLink" }}
-            </a>
-          </li>
-          {{# if isInRole 'admin' }}
+          {{# if currentUser }}
             <li>
-              <a href="{{ pathFor 'settings'}}">
-                <i class="fa fa-cog"></i>&nbsp;
-                {{_ "mainLayoutNavbar-settingsLink" }}
+              <a href="{{ pathFor 'userProfile'}}">
+                <i class="fa fa-user"></i>&nbsp;
+                {{_ "mainLayoutNavbar-profileLink" }}
               </a>
             </li>
+            {{# if isInRole 'admin' }}
+              <li>
+                <a href="{{ pathFor 'settings'}}">
+                  <i class="fa fa-cog"></i>&nbsp;
+                  {{_ "mainLayoutNavbar-settingsLink" }}
+                </a>
+              </li>
+            {{/ if }}
+            <li>
+              {{> logout }}
+            </li>
           {{/ if }}
-          <li>{{> logout }}</li>
         </ul>
-        {{/ if }}
+
       </div><!-- /.navbar-collapse -->
     </div><!-- /.container-fluid -->
   </nav>

--- a/app/client/routes/_config.js
+++ b/app/client/routes/_config.js
@@ -23,7 +23,9 @@ var anonymousRoutes = [
   'atSignIn',
   'atSignUp',
   'atVerifyEmail',
-  'atresendVerificationEmail'
+  'atresendVerificationEmail',
+  // Allow anonymous access to resident profile
+  'resident',
 ];
 
 // User login required for all areas of site

--- a/app/client/views/resident/resident.html
+++ b/app/client/views/resident/resident.html
@@ -1,6 +1,7 @@
 <template name="resident">
   {{#if Template.subscriptionsReady}}
     <h1 class="page-header">
+      {{# if currentUser }}
       <button type="button" class="btn btn-success pull-right" id="add-feeling">
         <i class="fa fa-stethoscope"></i>
         {{_ "resident-addFeeling-buttonText" }}
@@ -9,6 +10,7 @@
         <i class="fa fa-heartbeat"></i>
         {{_ "resident-addActivity-buttonText" }}
       </button>
+      {{/ if }}<!-- current user -->
 
       {{ resident.firstName }} {{ resident.lastInitial }}
 

--- a/app/client/views/resident/resident.html
+++ b/app/client/views/resident/resident.html
@@ -12,7 +12,12 @@
       </button>
       {{/ if }}<!-- current user -->
 
-      {{ resident.firstName }} {{ resident.lastInitial }}
+      {{ resident.firstName }}
+      &nbsp;
+      <!-- only show last initial for authenticated user -->
+      {{# if currentUser }}
+        {{ resident.lastInitial }}
+      {{/ if }}
 
       {{# if isInRole 'admin' }}
       <button id="edit-resident" class="btn btn-default">

--- a/app/client/views/resident/resident.js
+++ b/app/client/views/resident/resident.js
@@ -6,7 +6,7 @@ Template.resident.onCreated(function () {
   instance.residentId = Router.current().params.residentId;
 
   // Subscribe to current resident
-  instance.subscribe('residentComposite', instance.residentId);
+  instance.subscribe('residentProfileComposite', instance.residentId);
 
   // Subscribe to all roles except admin
   instance.subscribe("allRolesExceptAdmin");

--- a/app/server/publications/residentComposite.js
+++ b/app/server/publications/residentComposite.js
@@ -1,7 +1,21 @@
 Meteor.publishComposite('residentProfileComposite', function (residentId) {
   return {
     find: function () {
-      return Residents.find(residentId);
+      // Default fields for anonymous users
+      let fields = {
+        _id: 1,
+        firstName: 1,
+      }
+
+      // Some fields should only be published to authenticated users
+      if (Meteor.user) {
+        fields.lastInitial = 1;
+        fields.homeId = 1;
+        fields.onHiatus = 1;
+        fields.departed = 1;
+      }
+
+      return Residents.find(residentId, { fields });
     },
     children: [
       {

--- a/app/server/publications/residentComposite.js
+++ b/app/server/publications/residentComposite.js
@@ -1,4 +1,4 @@
-Meteor.publishComposite('residentComposite', function (residentId) {
+Meteor.publishComposite('residentProfileComposite', function (residentId) {
   return {
     find: function () {
       return Residents.find(residentId);
@@ -18,12 +18,6 @@ Meteor.publishComposite('residentComposite', function (residentId) {
           }
         ]
       },
-      {
-        find: function (resident) {
-          // Get resident Home
-          return Homes.find(resident.homeId);
-        }
-      }
     ]
   }
 });


### PR DESCRIPTION
Closes #226 

# Changes
- add rule to allow anonymous access to 'resident' route
- show navbar language select to anonymous users
- hide 'add activity' and 'add feeling' buttons on resident profile from anonymous users
- determine whether or not to show the resident name (first name, last initial) to anonymous users
  - legal, ethical, humanistic decision
- decided to hide resident last initial (only showing first name, since it is not as personally identifiable)
- control data publication for anonymous users to only get necessary fields