### PR TITLE
Fix: The Home Profile _resident activity level trends_ chart has a ho…

### DIFF
--- a/app/client/views/home/activities/trend/trend.js
+++ b/app/client/views/home/activities/trend/trend.js
@@ -58,13 +58,18 @@ Template.homeResidentActivityLevelTrend.onRendered(function () {
       // Add chart layout configuration
       const layout = {
         showlegend: true,
-        height: 333,
+        height: 232,
         legend: {
           x: 0,
-          y: 1.1,
+          y: 1.3,
           orientation: 'h'
         },
-        title: TAPi18n.__("homeResidentActivityLevelTrend-chartTitle"),
+        margin: {
+          r: 40,
+          t: 40,
+          b: 40,
+          l: 40
+        },
         yaxis: {
           title: TAPi18n.__("homeResidentActivityLevelTrend-yAxis-label"),
         }
@@ -75,7 +80,7 @@ Template.homeResidentActivityLevelTrend.onRendered(function () {
 
       // Render chart
       // coloring activity levels to match the 'traffic lights' theme :-)
-      Plotly.newPlot('trend-chart', [inactiveTrace, semiActiveTrace, activeTrace], layout, { locale });
+      Plotly.newPlot('trend-chart', [inactiveTrace, semiActiveTrace, activeTrace], layout, { locale, displayModeBar: false });
     }
   });
 });

--- a/app/client/views/home/home.html
+++ b/app/client/views/home/home.html
@@ -32,6 +32,9 @@
           </h2>
         </div>
         <div class="panel-body">
+          <p>
+            {{_ "homeResidentActivityLevelTrend-chartTitle"}}
+          </p>
           {{> homeResidentActivityLevelTrend }}
         </div>
       </div>


### PR DESCRIPTION
…rizontal legend along the top of the chart.
## Phone size
<img width="321" alt="screenshot at feb 11 11-03-01" src="https://user-images.githubusercontent.com/20643403/52551450-a299d380-2ded-11e9-8615-2b439b8618bf.png">

## Desktop size
<img width="1195" alt="screenshot at feb 11 11-03-37" src="https://user-images.githubusercontent.com/20643403/52551451-a3326a00-2ded-11e9-917c-200295c6579d.png">

## Table size
<img width="468" alt="screenshot at feb 11 11-03-19" src="https://user-images.githubusercontent.com/20643403/52551452-a3326a00-2ded-11e9-8065-57c490e02c2b.png">

Closes #325