### PR TITLE
 Adding a scrollbar to the group select dropdown

### DIFF
--- a/app/client/views/shared/userGroupsSelectWidget/widget.html
+++ b/app/client/views/shared/userGroupsSelectWidget/widget.html
@@ -1,5 +1,5 @@
 <template name="userGroupsSelectWidget">
-  <div class="form-group">
+  <div name="groupSelectForm" class="form-group">
     <label for="">
       {{_ "editUserGroups-groupsLabel" }}
     </label>

--- a/app/client/views/shared/userGroupsSelectWidget/wiget.css
+++ b/app/client/views/shared/userGroupsSelectWidget/wiget.css
@@ -1,0 +1,4 @@
+[name=groupSelectForm] .ss-multi-selected .ss-values{
+    max-height: 43px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
closes #406 , closes #402 
Adding a scrollbar to the group select dropdown
And fixing its height so that it does not obscure other components
giving group select form a name to use it as a unique css option