### PR TITLE
Register New User: Making sure emails have a TLD

### DIFF
--- a/app/lib/accounts.js
+++ b/app/lib/accounts.js
@@ -1,7 +1,7 @@
 const userEmailSchema = require("./userEmailSchema");
 AccountsTemplates.configure({
   // Behavior
-  forbidClientAccountCreation: false,
+  forbidClientAccountCreation: true,
   enablePasswordChange: true,
   showForgotPasswordLink: true
 });

--- a/app/lib/accounts.js
+++ b/app/lib/accounts.js
@@ -1,6 +1,7 @@
+const userEmailSchema = require("./userEmailSchema");
 AccountsTemplates.configure({
   // Behavior
-  forbidClientAccountCreation: true,
+  forbidClientAccountCreation: false,
   enablePasswordChange: true,
   showForgotPasswordLink: true
 });
@@ -18,22 +19,15 @@ AccountsTemplates.configureRoute("signIn");
 
 Meteor.startup(function () {
   Accounts.validateNewUser(function (user) {
-    if (!user) return false
-    if (!user.emails || (!!user.emails && user.emails.length === 0)) return false
-    const emailValidationRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    /* Iterates through all emails and checks if all emails are valid */
-    const areAllEmailsValid = user.emails.every(emailObject => {
-      const emailAddress = emailObject.address;
-      if (!emailAddress) return false
-      return emailValidationRegex.test(emailAddress);
-    })
-    if (!areAllEmailsValid)
+    const userEmailRecord = { emails: { ...user.emails } };
+    try {
+      userEmailSchema.validate(userEmailRecord);
+      return true
+    } catch (e) {
       // Must throw meteor error to show custom validation message
+      // Sending static error message for consistency with messages from previous validators
       throw new Meteor.Error(500, "Email: Invalid email");
-    
-    // return true in all other cases
-    return true
-
+    }
   });
   Accounts.emailTemplates.from = process.env.FROM_EMAIL;
   

--- a/app/lib/accounts.js
+++ b/app/lib/accounts.js
@@ -29,7 +29,7 @@ Meteor.startup(function () {
     })
     if (!areAllEmailsValid)
       // Must throw meteor error to show custom validation message
-      throw new Meteor.Error(500, "Email address is not valid!");
+      throw new Meteor.Error(500, "Email: Invalid email");
     
     // return true in all other cases
     return true

--- a/app/lib/accounts.js
+++ b/app/lib/accounts.js
@@ -16,6 +16,25 @@ AccountsTemplates.configureRoute("forgotPwd");
 AccountsTemplates.configureRoute("resetPwd");
 AccountsTemplates.configureRoute("signIn");
 
-Meteor.startup(function() {
+Meteor.startup(function () {
+  Accounts.validateNewUser(function (user) {
+    if (!user) return false
+    if (!user.emails || (!!user.emails && user.emails.length === 0)) return false
+    const emailValidationRegex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    /* Iterates through all emails and checks if all emails are valid */
+    const areAllEmailsValid = user.emails.every(emailObject => {
+      const emailAddress = emailObject.address;
+      if (!emailAddress) return false
+      return emailValidationRegex.test(emailAddress);
+    })
+    if (!areAllEmailsValid)
+      // Must throw meteor error to show custom validation message
+      throw new Meteor.Error(500, "Email address is not valid!");
+    
+    // return true in all other cases
+    return true
+
+  });
   Accounts.emailTemplates.from = process.env.FROM_EMAIL;
+  
 });

--- a/app/lib/userEmailSchema.js
+++ b/app/lib/userEmailSchema.js
@@ -1,0 +1,20 @@
+import SimpleSchema from 'simpl-schema';
+
+module.exports = new SimpleSchema({
+    emails: {
+        optional: false,
+        type: Object
+    },
+    "emails.$": {
+        type: Object
+    },
+    "emails.$.address": {
+        optional: true,
+        type: String,
+        regEx: SimpleSchema.RegEx.EmailWithTLD
+    },
+    "emails.$.verified": {
+        optional: true,
+        type: Boolean
+    }
+});


### PR DESCRIPTION
closes #391 

Meteor by default accepts email addresses without TLD (i.e. .[com]|[in] etc.). Adding a validation method so that email addresses without TLD are not accepted.