### PR TITLE
Adding validation messages

### DIFF
--- a/app/client/views/groups/modal/autoform.js
+++ b/app/client/views/groups/modal/autoform.js
@@ -1,6 +1,11 @@
 AutoForm.addHooks(['groupForm'], {
-  'onSuccess': function () {
+  onSuccess: function() {
     // Hide the modal dialogue
     Modal.hide('newGroup');
-  }
+  },
+  onError: function(formType, error) {
+    FlashMessages.sendError('<i class="fa fa-warning"></i> ' + error.message, {
+      autoHide: true,
+    });
+  },
 });

--- a/app/client/views/groups/modal/modal.html
+++ b/app/client/views/groups/modal/modal.html
@@ -3,6 +3,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
+          {{> flashMessages}}
           <h4 class="modal-title">
             <i class="fa fa-cubes"></i>&nbsp;
             {{# if group }}

--- a/app/client/views/home/edit/autoform.js
+++ b/app/client/views/home/edit/autoform.js
@@ -1,6 +1,11 @@
 AutoForm.addHooks(['editHomeForm'], {
-  'onSuccess': function () {
+  onSuccess: function() {
     // Hide the modal dialogue
     Modal.hide('editHome');
-  }
+  },
+  onError: function(formType, error) {
+    FlashMessages.sendError('<i class="fa fa-warning"></i> ' + error.message, {
+      autoHide: true,
+    });
+  },
 });

--- a/app/client/views/home/edit/edit.html
+++ b/app/client/views/home/edit/edit.html
@@ -4,6 +4,7 @@
       <div class="modal-content">
         {{# if Template.subscriptionsReady }}
         <div class="modal-header">
+          {{> flashMessages}}
           <h4 class="modal-title">
             {{_ "editHome-title" }}
           </h4>

--- a/app/client/views/homes/new/autoform.js
+++ b/app/client/views/homes/new/autoform.js
@@ -1,6 +1,11 @@
 AutoForm.addHooks(['newHomeForm'], {
-  'onSuccess': function () {
+  onSuccess: function() {
     // Hide the modal dialogue
     Modal.hide('newHome');
-  }
+  },
+  onError: function(formType, error) {
+    FlashMessages.sendError('<i class="fa fa-warning"></i> ' + error.message, {
+      autoHide: true,
+    });
+  },
 });

--- a/app/client/views/homes/new/newHome.html
+++ b/app/client/views/homes/new/newHome.html
@@ -4,6 +4,7 @@
       <div class="modal-content">
         {{# if Template.subscriptionsReady }}
         <div class="modal-header">
+          {{> flashMessages}}
           <h2 class="modal-title">
             <i class="fa fa-home"></i>
             {{_ "newHome-header-text" }}


### PR DESCRIPTION
closes #407 

Adding error messages when input is empty in the following modals:
1. add/edit group name
2. add/edit home name