### PR TITLE
Demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ meteor reset will delete the mock database
 This command will start a server on port 8000. It is better to run `npm i` if the tests are run for the first time.
 Server code must be tested on server using `Meteor.isServer` flag. Code running in the `if` constructs of `Meteor.isServer` will show results on the console. For the others, `Meteor.isClient` must be used and they can be evaluated in the browser on `http://localhost:8000`.
 
+
+## Steps to start the demo app
+1. Make sh file executable. Run `sudo chmod +x start-demo.sh`
+2. Make current user owner of meteor file by running `sudo chown -Rh shailee .meteor/local`
+3. The start-demo.sh file starts the app in demo mode (Make sure to not start it on the same server as the production server or else the mongo database will be overwritten).
+4. To start the demo as a cron job run 
+  1. `sudo crontab -e`
+  2. This will open a cronjob editor. On the last line of the editor add `0 0 * * * cd /path/to/sh-file && /bin/sh start-demo.sh >> cron.log 2>&1`.
+  3. Save and exit. This will restart and reset the app everyday at midnight.
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/app/packages/wellbeing-mock-data/wellbeing-mock-data.js
+++ b/app/packages/wellbeing-mock-data/wellbeing-mock-data.js
@@ -132,10 +132,10 @@ function createMockActivityTypes() {
 function createMockActivities() {
   console.log('Creating mock activies');
   // Number of activities to create per resident
-  var amount =  25;
+  var amount =  50;
 
   // Number, in days, for the earliest activity date
-  var earliestActivityDate = 30;
+  var earliestActivityDate = 365;
 
   // Get list of residents
   var residents = Residents.find().fetch();

--- a/app/packages/wellbeing-mock-data/wellbeing-mock-data.js
+++ b/app/packages/wellbeing-mock-data/wellbeing-mock-data.js
@@ -240,6 +240,7 @@ Meteor.methods({
     createMockActivityTypes();
     createMockActivities();
     createMockResidency(start, percentMovedOut);
+    Meteor.call('aggregateActivitiesAndPopulateAggregateCollection')
   },
   'createMockGroups': function () {
     createMockGroups();

--- a/app/server/crons/aggregateActivities.js
+++ b/app/server/crons/aggregateActivities.js
@@ -2,47 +2,8 @@ import { CronJob } from 'cron';
 
 new CronJob(
   '0 0 12 * * *',
-  Meteor.bindEnvironment(function(err, data) {
-    /* Get monthly data */
-    Meteor.call('getAllHomeReportAggregates', function(error, data) {
-      if (error || data.error === true) return;
-
-      /* Remove previous entries, if any so that after the following insert
-        there is always only one entry in the collection */
-      AllHomesActivityReportAggregate.remove({});
-      const lastUpdatedDate = new Date();
-
-      /* Prepapre data for insert adding 2 rows as per type bcause 
-         retival will be easy
-      */
-      const activityTypeData = {
-        lastUpdatedDate,
-        weeklyData: data.weeklyDataByActivityType,
-        aggregateBy: 'type',
-        monthlyData: data.monthlyDataByActivityType,
-      };
-      const facilitatorData = {
-        lastUpdatedDate,
-        weeklyData: data.weeklyDataByActivityFacilitator,
-        aggregateBy: 'facilitator',
-        monthlyData: data.monthlyDataByActivityFacilitator,
-      };
-
-      /* Insert Data */
-      AllHomesActivityReportAggregate.insert(
-        activityTypeData,
-        function(error) {
-          if (error) console.error('activityTypeData: ', error);
-        }
-      );
-
-      AllHomesActivityReportAggregate.insert(
-        facilitatorData,
-        function(error) {
-          if (error) console.error('facilitatorData: ', error);
-        }
-      );
-    });
+  Meteor.bindEnvironment(function() {
+    Meteor.call('aggregateActivitiesAndPopulateAggregateCollection');
   }),
   null,
   true

--- a/app/server/methods/activities.js
+++ b/app/server/methods/activities.js
@@ -344,6 +344,7 @@ export default Meteor.methods({
     };
 
   },
+  aggregateActivitiesAndPopulateAggregateCollection
 });
 
 
@@ -377,4 +378,47 @@ function prepareFilters(activityTypeId, residentId, userVisibleActiveResidentIds
       condition.$and.push({ activityTypeId });
     }
     return condition
+}
+
+function aggregateActivitiesAndPopulateAggregateCollection() {
+  /* Get monthly data */
+  Meteor.call('getAllHomeReportAggregates', function (error, data) {
+    if (error || data.error === true) return;
+
+    /* Remove previous entries, if any so that after the following insert
+      there is always only one entry in the collection */
+    AllHomesActivityReportAggregate.remove({});
+    const lastUpdatedDate = new Date();
+
+    /* Prepapre data for insert adding 2 rows as per type bcause 
+       retival will be easy
+    */
+    const activityTypeData = {
+      lastUpdatedDate,
+      weeklyData: data.weeklyDataByActivityType,
+      aggregateBy: 'type',
+      monthlyData: data.monthlyDataByActivityType,
+    };
+    const facilitatorData = {
+      lastUpdatedDate,
+      weeklyData: data.weeklyDataByActivityFacilitator,
+      aggregateBy: 'facilitator',
+      monthlyData: data.monthlyDataByActivityFacilitator,
+    };
+
+    /* Insert Data */
+    AllHomesActivityReportAggregate.insert(
+      activityTypeData,
+      function (error) {
+        if (error) console.error('activityTypeData: ', error);
+      }
+    );
+
+    AllHomesActivityReportAggregate.insert(
+      facilitatorData,
+      function (error) {
+        if (error) console.error('facilitatorData: ', error);
+      }
+    );
+  });
 }

--- a/app/server/methods/activities.js
+++ b/app/server/methods/activities.js
@@ -139,9 +139,10 @@ export default Meteor.methods({
       { fields: { [fieldSelector]: 1, lastUpdatedDate: 1, _id: 0 } },
       { sort: { Date: -1, limit: 1 } }
     );
+
     return {
       activityData: data ? data[fieldSelector] : [],
-      lastUpdated: data.lastUpdatedDate,
+      lastUpdated: data ? data.lastUpdatedDate : null,
     };
   },
   getResidentAggregatedActivities(residentId, timePeriod) {

--- a/app/server/startup.js
+++ b/app/server/startup.js
@@ -1,3 +1,38 @@
+import moment from 'moment';
+
 Meteor.startup(function() {
   Migrations.migrateTo('latest');
+
+  const mongoUrl = process.env.MONGO_URL;
+
+  if (
+    Meteor.isServer &&
+    mongoUrl.includes('27019') &&
+    mongoUrl.includes('wellbeing-demo')
+  ) {
+    /* Remove any users, if exist */
+    Meteor.users.remove({});
+
+    /* Create mock data */
+    Meteor.call(
+      'createMockData',
+      moment()
+        .subtract(365, 'days')
+        .toDate()
+    );
+
+    /* Create 2 users. One admin and a normal user */
+    const adminUser = Accounts.createUser({
+      username: 'Admin user',
+      email: 'admin@email.com',
+      password: '1234',
+    });
+    Roles.addUsersToRoles(adminUser, 'admin');
+
+    Accounts.createUser({
+      username: 'User',
+      email: 'user@email.com',
+      password: '1234',
+    });
+  }
 });

--- a/app/server/startup.js
+++ b/app/server/startup.js
@@ -2,14 +2,9 @@ import moment from 'moment';
 
 Meteor.startup(function() {
   Migrations.migrateTo('latest');
+  const isDemo = process.env.GERILIFE_DEMO === 'true';
 
-  const mongoUrl = process.env.MONGO_URL;
-
-  if (
-    Meteor.isServer &&
-    mongoUrl.includes('27019') &&
-    mongoUrl.includes('wellbeing-demo')
-  ) {
+  if (Meteor.isServer && isDemo) {
     /* Remove any users, if exist */
     Meteor.users.remove({});
 

--- a/app/start-demo.sh
+++ b/app/start-demo.sh
@@ -1,4 +1,5 @@
  #!/bin/bash
 export MONGO_URL="mongodb://localhost:27019/wellbeing-demo"
+export GERILIFE_DEMO=true
 mongo wellbeing-demo --port 27019 --eval "db.dropDatabase()"
 meteor --port 9000

--- a/app/start-demo.sh
+++ b/app/start-demo.sh
@@ -1,0 +1,4 @@
+ #!/bin/bash
+export MONGO_URL="mongodb://localhost:27019/wellbeing-demo"
+mongo wellbeing-demo --port 27019 --eval "db.dropDatabase()"
+meteor --port 9000

--- a/app/start-demo.sh
+++ b/app/start-demo.sh
@@ -8,3 +8,11 @@ export GERILIFE_DEMO=true
 /usr/local/bin/meteor --allow-superuser reset
 
 /usr/local/bin/meteor --allow-superuser --port 9000
+
+# Steps to start cron job
+## Make sh file executable
+## sudo chmod +x start-demo.sh
+## Make current user owner of meteor file
+## sudo chown -Rh shailee .meteor/local
+# Run cron job
+## 0 0 * * * cd /path/to/sh-file && /bin/sh start-demo.sh >> cron.log 2>&1

--- a/app/start-demo.sh
+++ b/app/start-demo.sh
@@ -1,5 +1,10 @@
  #!/bin/bash
-export MONGO_URL="mongodb://localhost:27019/wellbeing-demo"
+
+ #kill exisiting process
+ kill -9 $(ps axf | grep meteor | grep -v grep | awk '{print $1}')
+
+#start the new one
 export GERILIFE_DEMO=true
-mongo wellbeing-demo --port 27019 --eval "db.dropDatabase()"
-meteor --port 9000
+/usr/local/bin/meteor --allow-superuser reset
+
+/usr/local/bin/meteor --allow-superuser --port 9000

--- a/app/start-demo.sh
+++ b/app/start-demo.sh
@@ -8,11 +8,3 @@ export GERILIFE_DEMO=true
 /usr/local/bin/meteor --allow-superuser reset
 
 /usr/local/bin/meteor --allow-superuser --port 9000
-
-# Steps to start cron job
-## Make sh file executable
-## sudo chmod +x start-demo.sh
-## Make current user owner of meteor file
-## sudo chown -Rh shailee .meteor/local
-# Run cron job
-## 0 0 * * * cd /path/to/sh-file && /bin/sh start-demo.sh >> cron.log 2>&1


### PR DESCRIPTION
closes #512 
@brylie This is the basic idea of how a separate deployment can be done.

1. A shell script that must be run to start the server. It does the following actions in the given order
   a. Sets a separate URL to connect to for mongodb. Here, a port or a database name can be used which is different than that of its production counterpart.
  b. After that, it drops the existing databse on the given mongodb port.
  c. Run meteor on a new port.

2. On start up, based on the database name and port the app can identify if it is run in demo mode or not. If it is in demo mode then it will remove all existing users, run the `createMockData` method and also create 2 users. One admin and another non-admin.

Ofcourse, the start-demo.sh file must not be in the code base as it is deployment specific but I have committed it anyway to give you an idea of  I had in my mind.

Also I have used static database name and port to identify the demo mode. It will be ideal to set a environment variable for the mode which is read on startup and  the demo code is run. But currently we need to make sure that we aren't overwriting the production database so, I have hardcoded it. I would like your inputs on the this.